### PR TITLE
feat/ml date format 변환 수정

### DIFF
--- a/app/src/main/java/com/hackday/imageSearch/ml/MLLabelWorker.kt
+++ b/app/src/main/java/com/hackday/imageSearch/ml/MLLabelWorker.kt
@@ -107,7 +107,6 @@ class MLLabelWorker(private val context: Context, private val workerParams: Work
                     ).toString()
                     val mills = it.getLong(dateColumnIndex)
                     val date = generateDate(mills, "yyyy-MM-dd")
-                    Log.d("date taken",date)
                     val dateAdded = it.getLong(dateAddedColumnIndex).toString()
                     if (MyApplication.prefs.getUrl == null || MyApplication.prefs.getUrl.toString() < dateAdded) {
                         MyApplication.prefs.getUrl = dateAdded
@@ -188,8 +187,6 @@ class MLLabelWorker(private val context: Context, private val workerParams: Work
 
     private fun generateDate(mills: Long, dateformat: String): String {
         val formatter = SimpleDateFormat(dateformat)
-        val calendar = Calendar.getInstance()
-        calendar.setTimeInMillis(mills)
-        return formatter.format(calendar.timeInMillis)
+        return formatter.format(mills)
     }
 }


### PR DESCRIPTION
-LocalDateTime이  Api 26 이상에서만 작동하여 그 이하에서도 가능하도록 data 형식 변환할 때 Calendar를 사용해서 변환하도록 했습니다.