### PR TITLE
feat/mlkit-debug - adding photo error

### DIFF
--- a/app/src/main/java/com/hackday/imageSearch/MyApplication.kt
+++ b/app/src/main/java/com/hackday/imageSearch/MyApplication.kt
@@ -4,7 +4,8 @@ import android.app.Application
 import android.content.Context
 import com.hackday.imageSearch.di.appModule
 import com.hackday.imageSearch.di.viewModelModule
-import com.hackday.imageSearch.ml.MLManager
+import com.hackday.imageSearch.ml.MLLabelManager
+import com.hackday.imageSearch.ml.MLWorkerManager
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.context.startKoin
 
@@ -12,7 +13,8 @@ class MyApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
-        prefs = MLManager(applicationContext)
+        prefsLabel = MLLabelManager(applicationContext)
+        prefsUID = MLWorkerManager(applicationContext)
         startKoin {
             androidContext(this@MyApplication)
             modules(appModule)
@@ -26,7 +28,8 @@ class MyApplication : Application() {
 
     companion object {
 
-        lateinit var prefs: MLManager
+        lateinit var prefsLabel: MLLabelManager
+        lateinit var prefsUID: MLWorkerManager
         private var instance: MyApplication? = null
         fun applicationContext(): Context {
             return instance!!.applicationContext

--- a/app/src/main/java/com/hackday/imageSearch/ml/MLActivity.kt
+++ b/app/src/main/java/com/hackday/imageSearch/ml/MLActivity.kt
@@ -5,20 +5,25 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
+import androidx.lifecycle.Observer
 import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.WorkRequest
 import com.gun0912.tedpermission.PermissionListener
 import com.gun0912.tedpermission.TedPermission
+import com.hackday.imageSearch.MyApplication
 import com.hackday.imageSearch.R
 import com.hackday.imageSearch.databinding.ActivitySplashBinding
 import com.hackday.imageSearch.ui.main.MainActivity
+import java.util.*
 
 
 class MLActivity : AppCompatActivity() {
 
     private lateinit var viewModel: MLViewModel
 
+    @ExperimentalStdlibApi
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -26,8 +31,10 @@ class MLActivity : AppCompatActivity() {
             DataBindingUtil.setContentView(this, R.layout.activity_splash)
 
         getPermission()
+        //observeWorkEnded()
     }
 
+    @ExperimentalStdlibApi
     private fun getPermission() {
         var permissionListener: PermissionListener = object : PermissionListener {
 
@@ -51,25 +58,37 @@ class MLActivity : AppCompatActivity() {
             .check()
     }
 
+    @ExperimentalStdlibApi
     private fun startLabelWork() {
 
-        if (isRunningWorker()) {
-            val workRequest = createWorkRequest()
+        val workRequest = createWorkRequest()
+        if (MyApplication.prefsUID.lastUID == null) {
+            MyApplication.prefsUID.lastUID = workRequest.id.toString()
             startWorkRequest(workRequest)
         }
+        workerEnded(UUID.fromString(MyApplication.prefsUID.lastUID))
+
     }
 
     private fun createWorkRequest() = OneTimeWorkRequestBuilder<MLLabelWorker>()
-        .addTag("initWork")
         .build()
 
     private fun startWorkRequest(workRequest: WorkRequest) = getWorkManager().enqueue(workRequest)
 
     private fun getWorkManager() = WorkManager.getInstance(this)
 
-    private fun isRunningWorker() = getWorkManager().getWorkInfosByTag("initWork").get().isEmpty()
-
-
+    private fun workerEnded(workId: UUID) {
+        getWorkManager()
+            .getWorkInfoByIdLiveData(workId)
+            .observe(this, Observer { workInfo: WorkInfo? ->
+                workInfo?.let {
+                    if (workInfo.state == WorkInfo.State.SUCCEEDED) {
+                        MyApplication.prefsUID.lastUID = null
+                    }
+                }
+            })
+    }
 
 }
+
 

--- a/app/src/main/java/com/hackday/imageSearch/ml/MLLabelManager.kt
+++ b/app/src/main/java/com/hackday/imageSearch/ml/MLLabelManager.kt
@@ -1,0 +1,16 @@
+package com.hackday.imageSearch.ml
+
+import android.content.Context
+import android.content.SharedPreferences
+
+class MLLabelManager(context: Context) {
+
+    val fileName = "urlCheck"
+    val key = ""
+    val prefs: SharedPreferences = context.getSharedPreferences(fileName, 0)
+
+    var lastImageAddedDate: String?
+        get() = prefs.getString(key, null)
+        set(value) = prefs.edit().putString(key, value).apply()
+
+}

--- a/app/src/main/java/com/hackday/imageSearch/ml/MLLabelWorker.kt
+++ b/app/src/main/java/com/hackday/imageSearch/ml/MLLabelWorker.kt
@@ -44,7 +44,6 @@ class MLLabelWorker(private val context: Context, private val workerParams: Work
             e.printStackTrace()
             return Result.failure()
         }
-
         return Result.success()
     }
 
@@ -89,7 +88,7 @@ class MLLabelWorker(private val context: Context, private val workerParams: Work
             .query(
                 uri,
                 projection,
-                MyApplication.prefs.lastImageAddedDate,
+                MyApplication.prefsLabel.lastImageAddedDate,
                 null,
                 MediaStore.MediaColumns.DATE_ADDED + " desc"
             )
@@ -106,8 +105,8 @@ class MLLabelWorker(private val context: Context, private val workerParams: Work
                     val mills = it.getLong(dateColumnIndex)
                     val date = generateDate(mills, "yyyy-MM-dd")
                     val dateAdded = it.getLong(dateAddedColumnIndex).toString()
-                    if (MyApplication.prefs.lastImageAddedDate == null || MyApplication.prefs.lastImageAddedDate.toString() < dateAdded) {
-                        MyApplication.prefs.lastImageAddedDate = dateAdded
+                    if (MyApplication.prefsLabel.lastImageAddedDate == null || MyApplication.prefsLabel.lastImageAddedDate.toString() < dateAdded) {
+                        MyApplication.prefsLabel.lastImageAddedDate = dateAdded
                     }
                     PhotoInfoDatabase
                         .getInstance()
@@ -173,6 +172,7 @@ class MLLabelWorker(private val context: Context, private val workerParams: Work
 
     private fun reportProgress(current: Int, total: Int) {
 
+        Log.e("진행상황", current.toString() + " " + total.toString())
         val builder = NotificationCompat.Builder(applicationContext, "channelId")
             .setProgress(total, current, false)
             .setSmallIcon(androidx.work.R.drawable.notification_tile_bg)
@@ -183,10 +183,6 @@ class MLLabelWorker(private val context: Context, private val workerParams: Work
             ) as NotificationManager
         service.notify(1, builder.build());
 
-        if(current==total)
-        {
-            service.cancelAll()
-        }
     }
 
     private fun generateDate(mills: Long, dateformat: String): String {

--- a/app/src/main/java/com/hackday/imageSearch/ml/MLWorkerManager.kt
+++ b/app/src/main/java/com/hackday/imageSearch/ml/MLWorkerManager.kt
@@ -2,15 +2,15 @@ package com.hackday.imageSearch.ml
 
 import android.content.Context
 import android.content.SharedPreferences
+import java.util.*
 
-class MLManager(context: Context) {
+class MLWorkerManager (context: Context) {
 
-    val fileName = "urlCheck"
+    val fileName = "uidCheck"
     val key = ""
     val prefs: SharedPreferences = context.getSharedPreferences(fileName, 0)
 
-    var lastImageAddedDate: String?
+    var lastUID: String?
         get() = prefs.getString(key, null)
         set(value) = prefs.edit().putString(key, value).apply()
-
 }


### PR DESCRIPTION
SharedPreferences를 이용해서 현재 작업중인 worker.id(UUID)를 담아놓고 작업이 끝나면 null로 다시 바꿔 다른 worker가 도중에 끼어드는 것을 막았습니다.

멘토님께서 말씀하신 WorkManager.getWorkInfoById(), WorkManager.getWorkInfosByTag()
이거 두개는
첫번째는 UUID를 이용해서 worker를 식별 해야 하는데 매번 다시 들어올 때 마다 UUID가 바뀌니깐 어떻게 워커의 중복을 막는지 모르겠고 
두번째는 Tag이름을 정해놓고 그 Tag의 worker가 있으면 실행하지 않는 방향으로 구현하다가, 
해당 Tag를 가진 Worker가 끝나면 자동으로 사라지는게 아닌 것을 발견하였습니다..... 그래서 
 getWorkInfosByTag()를 observer 하려고 했으나 work의 상태를 옵저브 하는게 아니라 그 Tag를 가진 워커의 갯수의 변동을 옵저브 하여서 실패하였습니다...ㅠㅠㅠㅠㅠ